### PR TITLE
keeping dimension of data when subsetting

### DIFF
--- a/R/surfaceExtended.R
+++ b/R/surfaceExtended.R
@@ -119,7 +119,7 @@ surfaceExtended <- function(bwd_surface, data, tree, error = NA, models = c('OUM
 
   ###Data
   if(class(data) != 'data.frame') data <- data.frame(data)
-  if(any(!rownames(data) %in% tree$tip.label)) data <- data[-which(!rownames(data) %in% tree$tip.label),]
+  if(any(!rownames(data) %in% tree$tip.label)) data <- data[-which(!rownames(data) %in% tree$tip.label),,drop=FALSE]
 
   ###Tree
   if(length(tree$tip.label) != dim(data)[1]) {


### PR DESCRIPTION
When handling a mismatch between tree tip.label and data.frame row.names, it was converting the data.frame to a numeric vector, which no longer has a number of rows. This keeps the subsetted object as a data.frame.